### PR TITLE
refactor: memoise UserConfig

### DIFF
--- a/readwise_sqlalchemy/config.py
+++ b/readwise_sqlalchemy/config.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -13,9 +14,9 @@ class MissingEnvironmentFile(Exception):
 class UserConfig:
     """Object containing user configuration information."""
 
-    def __init__(self, user_dir: Path = Path.home()) -> None:
+    def __init__(self, user_dir: Path) -> None:
         """
-        Initialise object.
+        Initialise object. DO NOT USE DIRECTLY, use `fetch_user_config()` instead.
 
         Attributes
         ----------
@@ -63,4 +64,17 @@ class UserConfig:
             )
 
 
-USER_CONFIG = UserConfig()
+@lru_cache()
+def fetch_user_config(user_dir: Path = Path.home()) -> UserConfig:
+    """
+    Fetch the user configuration.
+
+    Memoize to ensure a single instance of UserConfig is used throughout the
+    application.
+
+    Returns
+    -------
+    UserConfig
+        The user configuration object.
+    """
+    return UserConfig(user_dir)

--- a/readwise_sqlalchemy/configure_logging.py
+++ b/readwise_sqlalchemy/configure_logging.py
@@ -3,10 +3,10 @@ from logging.handlers import RotatingFileHandler
 
 from rich.logging import RichHandler
 
-from readwise_sqlalchemy.config import USER_CONFIG, UserConfig
+from readwise_sqlalchemy.config import UserConfig, fetch_user_config
 
 
-def setup_logging(user_config: UserConfig = USER_CONFIG) -> None:
+def setup_logging(user_config: UserConfig = fetch_user_config()) -> None:
     """
     Setup logging.
 

--- a/readwise_sqlalchemy/utils.py
+++ b/readwise_sqlalchemy/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import DeclarativeBase
 
-from readwise_sqlalchemy.config import USER_CONFIG, UserConfig
+from readwise_sqlalchemy.config import UserConfig, fetch_user_config
 from readwise_sqlalchemy.main import fetch_from_export_api
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def get_columns_and_values(orm_mapped_obj: DeclarativeBase) -> dict[str, Any]:
 
 
 def create_real_user_data_json_for_end_to_end_testing(
-    user_config: UserConfig = USER_CONFIG,
+    user_config: UserConfig = fetch_user_config(),
 ) -> None:
     """
     Fetch your real Readwise highlights and store locally as test data.
@@ -73,7 +73,7 @@ def create_real_user_data_json_for_end_to_end_testing(
 
     Parameters
     ----------
-    user_config: UserConfig, default = USER_CONFIG
+    user_config: UserConfig, default = fetch_user_config()
         A UserConfig object.
     """
     target_file_path = user_config.app_dir / "my_readwise_highlights.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,8 +50,10 @@ def mock_user_config_module_scoped(
     required .env file with required synthetic data.
     """
     temp_application_dir = tmp_path_factory.mktemp("readwise-sqlalchemy")
+    temp_config_dir = temp_application_dir / ".config" / "rw-sql"
+    temp_config_dir.mkdir(parents=True)
 
-    temp_env_file = temp_application_dir / ".env"
+    temp_env_file = temp_config_dir / ".env"
     temp_env_file.touch()
     temp_env_file.write_text("READWISE_API_TOKEN = 'abc123'")
     user_config = UserConfig(temp_application_dir)

--- a/tests/e2e/test_main_e2e.py
+++ b/tests/e2e/test_main_e2e.py
@@ -10,7 +10,7 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from readwise_sqlalchemy.config import USER_CONFIG, UserConfig
+from readwise_sqlalchemy.config import UserConfig, fetch_user_config
 from readwise_sqlalchemy.db_operations import get_session
 from readwise_sqlalchemy.main import main
 from readwise_sqlalchemy.models import (
@@ -24,7 +24,7 @@ from readwise_sqlalchemy.models import (
 logger = logging.getLogger(__name__)
 
 
-E2E_TEST_DATA_PATH = USER_CONFIG.app_dir / "my_readwise_highlights.json"
+E2E_TEST_DATA_PATH = fetch_user_config().app_dir / "my_readwise_highlights.json"
 
 pytestmark = pytest.mark.skipif(
     not E2E_TEST_DATA_PATH.exists(),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,19 +1,49 @@
 import pytest
 
+from readwise_sqlalchemy.config import (
+    MissingEnvironmentFile,
+    UserConfig,
+    fetch_user_config,
+)
 
-class TestUserConfig:
-    @pytest.fixture
-    def add_temp_user_config_to_self(self, mock_user_config) -> None:
-        """Make `synthetic_user_config` available to all tests in the class."""
-        self.user_config = mock_user_config
 
-    @pytest.mark.parametrize(
-        "expected_is_true",
-        [
-            ("app_dir", lambda obj: obj.APPLICATION_DIR.is_dir()),
-            ("env_file", lambda obj: obj.ENV_FILE.exists()),
-            ("readwise_api_token", lambda obj: obj.READWISE_API_TOKEN == "abc123"),
-        ],
-    )
-    def test_init(self, expected_is_true):
-        assert expected_is_true
+@pytest.mark.parametrize(
+    "function_expected_is_true",
+    [
+        (lambda obj: obj.app_dir.is_dir()),
+        (lambda obj: obj.env_file.exists()),
+        (lambda obj: obj.readwise_api_token == "abc123"),
+    ],
+    ids=[
+        "app_dir_is_directory",
+        "env_file_exists",
+        "readwise_api_token_is_set",
+    ],
+)
+def test_init(mock_user_config, function_expected_is_true):
+    assert function_expected_is_true(mock_user_config)
+
+
+def test_user_config_objects_are_the_same_object_instance(mock_user_config):
+    user_config_1 = fetch_user_config(mock_user_config.user_dir)
+    user_config_2 = fetch_user_config(mock_user_config.user_dir)
+    assert user_config_1 is user_config_2
+
+
+def test_user_config_objects_are_different_instances(
+    mock_user_config: UserConfig,
+    mock_user_config_module_scoped: UserConfig,
+):
+    user_config_1 = fetch_user_config(mock_user_config.user_dir)
+    user_config_2 = fetch_user_config(mock_user_config_module_scoped.user_dir)
+    assert user_config_1 is not user_config_2
+
+
+def test_missing_env_file_raises_exception(
+    tmp_path: pytest.TempPathFactory,
+):
+    with pytest.raises(
+        MissingEnvironmentFile,
+        match="A '.env' file is expected in the '~/.config/rw-sql' directory.",
+    ):
+        UserConfig(tmp_path)


### PR DESCRIPTION
Use functools lru_cache to memoise the UserConfig object via a setup function. Ensures that the a uniform user config is used throughout the application.